### PR TITLE
Add extra command-line flags to chromium binary.

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -9,6 +9,7 @@ B = "${WORKDIR}/build/${OUTPUT_DIR}"
 
 SRC_URI += " \
         ${@bb.utils.contains('PACKAGECONFIG', 'root-profile', 'file://root-user-profile.patch', '', d)} \
+        file://wrapper-extra-flags.patch \
         "
 
 # At the moment, this recipe has only been tested on i586, x86-64, ARMv6,
@@ -295,6 +296,10 @@ do_install() {
 		${WRAPPER_FILE} > chromium-wrapper
 	install -m 0755 chromium-wrapper ${D}${libdir}/chromium/chromium-wrapper
 	ln -s ${libdir}/chromium/chromium-wrapper ${D}${bindir}/chromium
+
+	# Add extra command line arguments to the chromium-wrapper script by
+	# modifying the dummy "CHROME_EXTRA_ARGS" line
+	sed -i "s/^CHROME_EXTRA_ARGS=\"\"/CHROME_EXTRA_ARGS=\"${CHROMIUM_EXTRA_ARGS}\"/" ${D}${libdir}/chromium/chromium-wrapper
 
 	install -m 4755 chrome_sandbox ${D}${libdir}/chromium/chrome-sandbox
 	install -m 0755 chrome ${D}${libdir}/chromium/chromium-bin

--- a/recipes-browser/chromium/files/wrapper-extra-flags.patch
+++ b/recipes-browser/chromium/files/wrapper-extra-flags.patch
@@ -1,0 +1,17 @@
+Upstream-Status: Inappropriate [embedder specific]
+
+The patch below is used to allow running Chromium as root as well as passing
+extra flags to it by default.
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+--- a/chrome/installer/linux/common/wrapper
++++ b/chrome/installer/linux/common/wrapper
+@@ -45,5 +45,7 @@
+ exec > >(exec cat)
+ exec 2> >(exec cat >&2)
+ 
++CHROME_EXTRA_ARGS=""
++
+ # Note: exec -a below is a bashism.
+-exec -a "$0" "$HERE/@@PROGNAME@@" "$@"
++exec -a "$0" "$HERE/@@PROGNAME@@" ${CHROME_EXTRA_ARGS} "$@"


### PR DESCRIPTION
The variable CHROMIUM_EXTRA_ARGS can be used for that purpose. Extra
args will be added to the chromium wrapper.

Based on code from https://github.com/OSSystems/meta-browser